### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 		maven {
 			url "https://plugins.gradle.org/m2/"
 		}
-		maven { url "http://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/plugins-release" }
 	}
 
 	dependencies {
@@ -40,7 +40,7 @@ apply from: file('gradle/maven.gradle')
 repositories {
 	mavenCentral()
 //    maven { url 'https://oss.jfrog.org/libs-snapshot' }
-    maven { url 'http://repo.spring.io/libs-snapshot' }
+    maven { url 'https://repo.spring.io/libs-snapshot' }
 }
 
 apply plugin: 'maven'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -24,12 +24,12 @@ def customizePom(def pom, def gradleProject) {
 			url = "https://github.com/reactor/${rootProject.githubProjectName}"
 			organization {
 				name = 'reactor'
-				url = 'http://github.com/reactor'
+				url = 'https://github.com/reactor'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/reactor migrated to:  
  https://github.com/reactor ([https](https://github.com/reactor) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).