### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 *.ear
 /build/
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 
 hs_err_pid* 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Here are some questions that you should be able to answer beforehand:
   - Can you write a properly backpressured, single element Publisher (`just()`)  from scratch?
   - Do you understand the various concurrent queue types and when to use them?
   
-It is also advised you read @akarnokd's blog about [Advanced RxJava](http://akarnokd.blogspot.hu/) (beginning with the very first post and moving forward in time). Most RxJava constructs are about a relatively simple transformation away from Reactive-Streams constructs.
+It is also advised you read @akarnokd's blog about [Advanced RxJava](https://akarnokd.blogspot.hu/) (beginning with the very first post and moving forward in time). Most RxJava constructs are about a relatively simple transformation away from Reactive-Streams constructs.
 
 ## Asking questions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # reactive-streams-commons
 A joint research effort for building highly optimized Reactive-Streams compliant operators.
-Current implementors include [RxJava2](https://github.com/ReactiveX/RxJava) and [Reactor](http://github.com/reactor/reactor-core).
+Current implementors include [RxJava2](https://github.com/ReactiveX/RxJava) and [Reactor](https://github.com/reactor/reactor-core).
 
 Java 8 required.
 
@@ -10,7 +10,7 @@ Java 8 required.
 
 ```
 repositories {
-    maven { url 'http://repo.spring.io/libs-snapshot' }
+    maven { url 'https://repo.spring.io/libs-snapshot' }
 }
 
 dependencies {
@@ -18,12 +18,12 @@ dependencies {
 }
 ```
 
-[Snapshot](http://repo.spring.io/libs-snapshot/io/projectreactor/reactive-streams-commons/) directory.
+[Snapshot](https://repo.spring.io/libs-snapshot/io/projectreactor/reactive-streams-commons/) directory.
 
 ## Operator-fusion documentation
 
-  - [Operator fusion, 1/2](http://akarnokd.blogspot.hu/2016/03/operator-fusion-part-1.html)
-  - [Operator fusion, 2/2](http://akarnokd.blogspot.hu/2016/04/operator-fusion-part-2-final.html)
+  - [Operator fusion, 1/2](https://akarnokd.blogspot.hu/2016/03/operator-fusion-part-1.html)
+  - [Operator fusion, 2/2](https://akarnokd.blogspot.hu/2016/04/operator-fusion-part-2-final.html)
   - [Fusion Matrix](https://rawgit.com/reactor/reactive-streams-commons/master/fusion-matrix.html)
 
 ## Supported datasources


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/reactor/reactor-core with 1 occurrences migrated to:  
  https://github.com/reactor/reactor-core ([https](https://github.com/reactor/reactor-core) result 200).
* http://repo.spring.io/libs-snapshot/io/projectreactor/reactive-streams-commons/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot/io/projectreactor/reactive-streams-commons/ ([https](https://repo.spring.io/libs-snapshot/io/projectreactor/reactive-streams-commons/) result 200).
* http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).
* http://akarnokd.blogspot.hu/ with 1 occurrences migrated to:  
  https://akarnokd.blogspot.hu/ ([https](https://akarnokd.blogspot.hu/) result 302).
* http://akarnokd.blogspot.hu/2016/03/operator-fusion-part-1.html with 1 occurrences migrated to:  
  https://akarnokd.blogspot.hu/2016/03/operator-fusion-part-1.html ([https](https://akarnokd.blogspot.hu/2016/03/operator-fusion-part-1.html) result 302).
* http://akarnokd.blogspot.hu/2016/04/operator-fusion-part-2-final.html with 1 occurrences migrated to:  
  https://akarnokd.blogspot.hu/2016/04/operator-fusion-part-2-final.html ([https](https://akarnokd.blogspot.hu/2016/04/operator-fusion-part-2-final.html) result 302).
* http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).